### PR TITLE
Add instructions find marketplace in Plugins.

### DIFF
--- a/docs/jetbrains/gettingstarted.md
+++ b/docs/jetbrains/gettingstarted.md
@@ -15,7 +15,7 @@
 ## 1. Installing the JetBrains extension
 
 1. We have tested with the following JetBrains IDEs: IntelliJ and PyCharm versions 2021.2 and above.
-2. From the JetBrains marketplace, search for 'github copilot'.  (You must include the 'github' to avoid other plug-ins with similar names.)
+2. From Settings/Preferences > Plugins, in the JetBrains marketplace, search for 'github copilot'.  (You must include the 'github' to avoid other plug-ins with similar names.)
 
    <img src='resources\search-for-github-copilot_jetbrains.png' width="600px" alt="Search for `github copilot`"/>
 


### PR DESCRIPTION
Spent some time searching around to find the "Marketplace", not clear that it's in the "Plugins" menu. The search term "marketplace" isn't helpful in Jetbrains help. Probably good argument for it to be mentioned explicitly. Copied language from https://www.jetbrains.com/help/idea/settings-preferences-dialog.html
